### PR TITLE
Allow to specify class loader(s) in EntityScanner

### DIFF
--- a/fluent-hibernate-core/src/main/java/com/github/fluent/hibernate/cfg/scanner/EntityScanner.java
+++ b/fluent-hibernate-core/src/main/java/com/github/fluent/hibernate/cfg/scanner/EntityScanner.java
@@ -52,14 +52,32 @@ public final class EntityScanner {
      */
     public static EntityScanner scanPackages(String... packages) {
         Asserts.isTrue(!CollectionUtils.isEmptyEllipsis(packages),
-                "You should to specify almost one package to scan.");
+                "You should to specify at least one package to scan.");
         return scanPackages(packages, null, Entity.class);
+    }
+
+    /**
+     * Scan packages for the @Entity annotation.
+     *
+     * @param loaders
+     *            one or more class loaders to find classes in
+     * @param packages
+     *            one or more Java package names
+     *
+     * @return EntityScanner for fluent calls
+     */
+    public static EntityScanner scanPackages(List<ClassLoader> loaders, String... packages) {
+        Asserts.isTrue(!CollectionUtils.isEmptyEllipsis(packages),
+                "You should to specify at least one package to scan.");
+        Asserts.isTrue(!CollectionUtils.isEmpty(loaders),
+                "You should to specify at least one class loader.");
+        return scanPackages(packages, loaders, Entity.class);
     }
 
     private static EntityScanner scanPackages(String[] packages, List<ClassLoader> loaders,
             Class<? extends Annotation> annotation) {
         try {
-            return scanPackagesInternal(packages, null, Entity.class);
+            return scanPackagesInternal(packages, loaders, annotation);
         } catch (Exception ex) {
             throw InternalUtils.toRuntimeException(ex);
         }


### PR DESCRIPTION
Hello,

**Background**
I'm using fluent-hibernate to automatically discover my entity classes. My classes are loaded by a container that uses a class loader different from the context class loader that EntityScanner seems to default to. Because of that, my entities are not being discovered. When specifying the correct class loader using the private API and a debugger, the entities are found just fine.

**The issue**
Currently, the public API does not provide a way of specifying what class loader to use to actually get the classes, even though the underlying implementation does support that.

**PR Breakdown**
This PR adds a new method to EntityScanner to scan for entities in given packages and using a list of class loaders. Usually, I would imagine that only a single class loader would be used, but the underlying implementation uses a list, and I figured there could be a reason for that. 
Note that the single-varargs method does not call the other one because it would throw an exception for the list of loaders being null. I decided not to allow a null list of loaders because that's the same behaviour as the loader-less method, but less clear. Readers of the code could only assume what the first null argument means, resulting in less readability.

Thanks!
